### PR TITLE
WIP Cran proxy

### DIFF
--- a/reverse_proxy/defaults/main.yml
+++ b/reverse_proxy/defaults/main.yml
@@ -4,3 +4,7 @@ zone: hic-tre.dundee.ac.uk
 
 # If test is set to true, we will also provision a git smart http service.
 test: false
+
+# cran mirror
+#cran_mirror: https://www.stats.bris.ac.uk/R/
+cran_mirror: https://cran.ma.imperial.ac.uk/

--- a/reverse_proxy/molecule/default/molecule.yml
+++ b/reverse_proxy/molecule/default/molecule.yml
@@ -17,5 +17,6 @@ provisioner:
     group_vars:
       all:
         test: true
+        zone: localhost
 verifier:
   name: ansible

--- a/reverse_proxy/molecule/default/verify.yml
+++ b/reverse_proxy/molecule/default/verify.yml
@@ -25,6 +25,9 @@
       fail_msg: "The nginx service is not enabled (set to start at boot)"
       success_msg: "The nginx service will start automatically"
 
+######################################################################
+# git-test tests
+
   - name: interact with with git via smart http directly
     become: true
     shell: |
@@ -44,6 +47,10 @@
       that: git_direct.rc == 0
       fail_msg: "Cloning a public repo failed"
       success_msg: "Cloning a public repo was successful"
+
+
+######################################################################
+# git proxy tests
 
   - name: pull via proxy
     become: true
@@ -78,3 +85,93 @@
       that: git_push_proxy.rc != 0
       fail_msg: "Git push via the proxy should not have succeeded!"
       success_msg: "Pushing via proxy failed."
+
+######################################################################
+# cran proxy tests
+
+  - name: test connection to /
+    uri:
+      url: http://cran.{{zone}}/
+      force: true  # avoid hitting cache
+    failed_when: false
+    changed_when: false
+    register: r_curl_root
+
+  - name: test connection to /
+    assert:
+      that: r_curl_root.status == 403
+      fail_msg: "CRAN mirror requests without file extensions should fail"
+      success_msg: "Request without file extension was successfully blocked"
+
+  - name: test connection to /index.html
+    uri:
+      url: http://cran.{{zone}}/index.html
+      force: true  # avoid hitting cache
+    failed_when: false
+    changed_when: false
+    register: r_curl_html
+
+  - name: test connection to /index.html
+    assert:
+      that: r_curl_html.status == 200
+      fail_msg: "Request to valid file extension was not blocked."
+      success_msg: "Request with valid file extension was accepted"
+
+  - name: test connection to /index.php
+    uri:
+      url: http://cran.{{zone}}/index.php
+      force: true  # avoid hitting cache
+    failed_when: false
+    changed_when: false
+    register: r_curl_php
+
+  - name: test connection to /index.php
+    assert:
+      that: r_curl_php.status == 403
+      fail_msg: "Request to invalid file extension was not blocked."
+      success_msg: "Request to invlaid file extension was blocked."
+
+  - name: r package installation
+    shell:
+      cmd: |
+        rm -rf /usr/local/lib/R/site-library/ggplot2 # remove if installed
+        /usr/bin/R --no-save <<RPROG
+        install.packages("ggplot2", repos="http://cran.{{zone}}")
+        library('ggplot2')
+        q()
+        RPROG
+    failed_when: false
+    changed_when: false
+    register: r_install
+
+  - name: ensure r package installed successfully
+    assert:
+      that: r_install.rc == 0
+      fail_msg: "Failed to install R package (ggplot2) from local proxy"
+      success_msg: "R package (ggplot2) was successfully installed via local proxy"
+
+  - name: check avscanner headers
+    uri:
+      url: http://cran.{{zone}}/index.html
+      force: true  # avoid hitting cache
+    failed_when: false
+    changed_when: false
+    register: r_curl_headers
+
+  - name: verify X-Sophos-Return-Code header is set and zero
+    assert:
+      that: r_curl_headers.x_sophos_return_code == "0"
+      fail_msg: "Missing header X-Sophos-Return-Code"
+      success_msg: "Header X-Sophos-Return-Code was set"
+
+  - name: verify X-Sophos-Scan-Timer header is set
+    assert:
+      that: r_curl_headers.x_sophos_scan_timer
+      fail_msg: "Missing header X-Sophos-Scan-Timer"
+      success_msg: "Header X-Sophos-Scan-Timer was set"
+
+  - name: verify X-Sophos-Temporary-File header is set
+    assert:
+      that: r_curl_headers.x_sophos_temporary_file
+      fail_msg: "Missing header X-Sophos-Temporary-File"
+      success_msg: "Header X-Sophos-Temporary-File was set"

--- a/reverse_proxy/molecule/default/verify.yml
+++ b/reverse_proxy/molecule/default/verify.yml
@@ -49,7 +49,7 @@
     become: true
     shell: |
       [ -d repo ] && rm -rf repo
-      git clone http://user:password@localhost/test.git repo
+      git clone http://user:password@github.{{zone}}/test.git repo
       cd repo
       git status
       git pull origin master

--- a/reverse_proxy/tasks/cran.yml
+++ b/reverse_proxy/tasks/cran.yml
@@ -1,0 +1,8 @@
+---
+
+- name: add our cran reverse proxy config
+  become: true
+  template:
+    dest: /etc/nginx/sites-enabled/cran.conf
+    src: cran.conf.j2
+  notify: restart nginx

--- a/reverse_proxy/tasks/cran_test.yml
+++ b/reverse_proxy/tasks/cran_test.yml
@@ -6,3 +6,16 @@
     path: /etc/hosts
     line: 127.0.0.1 cran.{{zone}}
     unsafe_writes: true # issue with testing inside a container
+- name: create faux sophos-spl installation
+  become: true
+  file:
+    state: directory
+    recurse: true
+    dest: /opt/sophos-spl/plugins/av/bin
+
+- name: create a faux avscanner tool
+  become: true
+  file:
+    state: link
+    src: /usr/bin/true
+    dest: /opt/sophos-spl/plugins/av/bin/avscanner

--- a/reverse_proxy/tasks/cran_test.yml
+++ b/reverse_proxy/tasks/cran_test.yml
@@ -6,6 +6,15 @@
     path: /etc/hosts
     line: 127.0.0.1 cran.{{zone}}
     unsafe_writes: true # issue with testing inside a container
+
+- name: install R for testing package installation
+  become: true
+  apt:
+    name:
+      - r-base
+      - build-essential
+    install_recommends: false
+
 - name: create faux sophos-spl installation
   become: true
   file:

--- a/reverse_proxy/tasks/cran_test.yml
+++ b/reverse_proxy/tasks/cran_test.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: add testing endpoint to /etc/hosts
+  become: true
   lineinfile:
     path: /etc/hosts
     line: 127.0.0.1 cran.{{zone}}
+    unsafe_writes: true # issue with testing inside a container

--- a/reverse_proxy/tasks/cran_test.yml
+++ b/reverse_proxy/tasks/cran_test.yml
@@ -1,0 +1,6 @@
+---
+
+- name: add testing endpoint to /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    line: 127.0.0.1 cran.{{zone}}

--- a/reverse_proxy/tasks/github_test.yml
+++ b/reverse_proxy/tasks/github_test.yml
@@ -7,6 +7,11 @@
     src: github_test.conf.j2
   notify: restart nginx
 
+- name: add testing endpoint to /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    line: 127.0.0.1 github.{{zone}}
+
 - name: install dependencies for testing
   become: true
   apt:

--- a/reverse_proxy/tasks/github_test.yml
+++ b/reverse_proxy/tasks/github_test.yml
@@ -8,9 +8,11 @@
   notify: restart nginx
 
 - name: add testing endpoint to /etc/hosts
+  become: true
   lineinfile:
     path: /etc/hosts
     line: 127.0.0.1 github.{{zone}}
+    unsafe_writes: true # issue with testing inside a container
 
 - name: install dependencies for testing
   become: true

--- a/reverse_proxy/tasks/main.yml
+++ b/reverse_proxy/tasks/main.yml
@@ -15,3 +15,5 @@
 - include_tasks: github.yml
 - include_tasks: github_test.yml
   when: test
+
+- include_tasks: cran.yml

--- a/reverse_proxy/tasks/main.yml
+++ b/reverse_proxy/tasks/main.yml
@@ -17,3 +17,5 @@
   when: test
 
 - include_tasks: cran.yml
+- include_tasks: cran_test.yml
+  when: test

--- a/reverse_proxy/templates/cran.conf.j2
+++ b/reverse_proxy/templates/cran.conf.j2
@@ -38,6 +38,13 @@ server {
       ngx.header["X-Sophos-Return-Code"] = tostring(ret)
       ngx.header["X-Sophos-Temporary-File"] = path
 
+      if ret == 0 then
+        ngx.say(res.body)
+      else
+        ngx.header["Content-Type"] = "text/plain"
+        ngx.say("Mallicious content was detected in the requested file.")
+      end
+
     }
   }
 }

--- a/reverse_proxy/templates/cran.conf.j2
+++ b/reverse_proxy/templates/cran.conf.j2
@@ -2,7 +2,16 @@ server {
   listen 80;
   server_name cran.{{zone}};
 
+  location /cran-fetch {
+    internal;
+    proxy_pass {{cran_mirror}};
+  }
+
   location / {
+    # prevent cyclic location.capture
+    if ($request_uri ~ /cran-fetch) { break; }
+
+    # ensure we are only processing GET requests
     access_by_lua_block {
       function reject ()
         ngx.exit(403)
@@ -14,6 +23,22 @@ server {
       end
     }
 
-    proxy_pass {{cran_mirror}};
+    # rewrite the request so we have an opportunity to scan the file
+    rewrite_by_lua_block {
+      local res = ngx.location.capture("/cran-fetch" .. ngx.var.uri);
+
+      local path = os.tmpname()
+
+      local file = io.open(path, "w")
+      file:write(res.body)
+      file:close()
+
+      local ret = os.execute("/opt/sophos-spl/plugins/av/bin/avscanner " .. path)
+
+      ngx.header["X-Sophos-Return-Code"] = tostring(ret)
+      ngx.header["X-Sophos-Temporary-File"] = path
+
+    }
   }
 }
+

--- a/reverse_proxy/templates/cran.conf.j2
+++ b/reverse_proxy/templates/cran.conf.j2
@@ -1,0 +1,19 @@
+server {
+  listen 80;
+  server_name cran.{{zone}};
+
+  location / {
+    access_by_lua_block {
+      function reject ()
+        ngx.exit(403)
+      end
+
+      local method = ngx.var.request_method
+      if method ~= "GET" then
+        reject()
+      end
+    }
+
+    proxy_pass {{cran_mirror}};
+  }
+}

--- a/reverse_proxy/templates/cran.conf.j2
+++ b/reverse_proxy/templates/cran.conf.j2
@@ -33,10 +33,15 @@ server {
       file:write(res.body)
       file:close()
 
+      local t_start = os.clock()
       local ret = os.execute("/opt/sophos-spl/plugins/av/bin/avscanner " .. path)
+      local t_end = os.clock()
+
+      os.remove(path)
 
       ngx.header["X-Sophos-Return-Code"] = tostring(ret)
       ngx.header["X-Sophos-Temporary-File"] = path
+      ngx.header["X-Sophos-Scan-Timer"] = tostring(t_end - t_start) .. " cpu seconds"
 
       if ret == 0 then
         ngx.say(res.body)

--- a/reverse_proxy/templates/cran.conf.j2
+++ b/reverse_proxy/templates/cran.conf.j2
@@ -28,7 +28,7 @@ server {
 
       local valid = false
       local extensions = {
-        '.html', '.css', '.svg', '.tar.gz', '.tar.bzip', '.zip'
+        '.html', '.css', '.svg', '.tar.gz', '.tar.bzip', '.zip', "PACKAGES"
       }
       for e=1,#extensions do
         valid = valid or ends_with(ngx.var.uri, extensions[e])

--- a/reverse_proxy/templates/cran.conf.j2
+++ b/reverse_proxy/templates/cran.conf.j2
@@ -12,19 +12,30 @@ server {
     if ($request_uri ~ /cran-fetch) { break; }
 
     # ensure we are only processing GET requests
-    access_by_lua_block {
+    rewrite_by_lua_block {
       function reject ()
         ngx.exit(403)
+      end
+
+      function ends_with (s, e)
+        return s:sub(-#e) == e
       end
 
       local method = ngx.var.request_method
       if method ~= "GET" then
         reject()
       end
-    }
 
-    # rewrite the request so we have an opportunity to scan the file
-    rewrite_by_lua_block {
+      local valid = false
+      local extensions = {
+        '.html', '.css', '.svg', '.tar.gz', '.tar.bzip', '.zip'
+      }
+      for e=1,#extensions do
+        valid = valid or ends_with(ngx.var.uri, extensions[e])
+      end
+
+      if not valid then reject() end
+
       local res = ngx.location.capture("/cran-fetch" .. ngx.var.uri);
 
       local path = os.tmpname()
@@ -49,7 +60,6 @@ server {
         ngx.header["Content-Type"] = "text/plain"
         ngx.say("Mallicious content was detected in the requested file.")
       end
-
     }
   }
 }


### PR DESCRIPTION
This PR configures nginx as a reverse proxy for CRAN. It ensures that only GET requests are made to specific file extensions. The files are written to a temporary file and scanned using Sophos avscanner.