### PR TITLE
CI: Remove concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
     name: Run Molecule
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         role:
           - squid

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,6 @@ name: Test roles
     paths-ignore:
       - '**/*.md'
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
 
   lint:


### PR DESCRIPTION
This isn't used for deployments so there's no point blocking other runs