### PR TITLE
Replace internal proxy pass with curl

### DIFF
--- a/reverse_proxy/molecule/default/converge.yml
+++ b/reverse_proxy/molecule/default/converge.yml
@@ -36,15 +36,12 @@
         install_recommends: false
       register: clamav_install
 
-    - name: Create an EICAR file
+    - name: Create an EICAR signature db for ClamAV
       copy:
+        # This is the sha256 with file length and a name
         content: |
-          X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
-        dest: /tmp/eicar.txt
-
-    - name: Create a dummy database
-      become: true
-      shell: sigtool --sha256 /tmp/eicar.txt > /tmp/clamav.hdb
+          131f95c51cc819465fa1797f6ccacf9d494aaaff46fa3eac73ae63ffbdfd8267:69:eicar
+        dest: /tmp/clamav.hdb
       when: clamav_install.changed
 
     - name: create faux sophos-spl installation

--- a/reverse_proxy/templates/generic.conf.j2
+++ b/reverse_proxy/templates/generic.conf.j2
@@ -5,7 +5,13 @@ server {
   # Internal only endpoint for performing a proxy pass to the cran mirror.
   location /{{ generic_name }}-fetch {
     internal;
-    proxy_pass {{ upstream_endpoint }};
+    rewrite_by_lua_block {
+      local uri = ngx.var.uri:gsub("{{ generic_name }}%-fetch", "")
+      local curl = io.popen("/usr/bin/curl \"{{ upstream_endpoint }}" .. uri .. "\"")
+      ngx.print(curl:read('*a'))
+      curl:close();
+      ngx.exit(ngx.HTTP_OK)
+    }
   }
 
   # Define an EICAR endpoint for verifying that the reverse proxy is


### PR DESCRIPTION
I think something in the TLS headers makes CloudFlare pick the ProxyPass up as unusual traffic. Switching to curl fixes this. 

During review please give a bit of attention to the possibility of shell injection from user input. It seems unlikely since it has to get through the regex but definitely deserves some additional eyes 👀 